### PR TITLE
fix: query params isn't replaced by Endpoint class so no need to set …

### DIFF
--- a/onesignal/api/default_api.py
+++ b/onesignal/api/default_api.py
@@ -910,7 +910,7 @@ class DefaultApi(object):
                 'auth': [
                     'app_key'
                 ],
-                'endpoint_path': '/notifications/{notification_id}/export_events?app_id={app_id}',
+                'endpoint_path': '/notifications/{notification_id}/export_events',
                 'operation_id': 'export_events',
                 'http_method': 'POST',
                 'servers': None,
@@ -967,7 +967,7 @@ class DefaultApi(object):
                 'auth': [
                     'app_key'
                 ],
-                'endpoint_path': '/players/csv_export?app_id={app_id}',
+                'endpoint_path': '/players/csv_export',
                 'operation_id': 'export_players',
                 'http_method': 'POST',
                 'servers': None,


### PR DESCRIPTION
# Description
## One Line Summary
Fix #32 

## Details

### Motivation
query parameters that are passed to the Endpoint class were not removed.
For example; When calling the `export_events` function, the API client send a request to the URL like `https://onesignal.com/api/v1/notifications/4133437f-888c-4a6c-82af-a1d320ad8b31/export_events?app_id={app_id}`. As app_id is not replaced, so that the server response 400 bad request error.

### Scope
`export_events` and `export_players` will be fix.

### OPTIONAL - Other

# Testing

## Manual testing
Confirm that the below code works
```python
with onesignal.ApiClient(configuration) as api_client:
    # Create an instance of the API class
    api_instance = default_api.DefaultApi(api_client)

    # example passing only required values which don't have defaults set
    try:
        # Export CSV of Events
        api_response = api_instance.export_events(notification_id, app_id)
        pprint(api_response)
    except onesignal.ApiException as e:
        print("Exception when calling DefaultApi->export_events: %s\n" % e)

```


# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.