### PR TITLE
Add v5.4.0 package updates

### DIFF
--- a/docs/DefaultApi.md
+++ b/docs/DefaultApi.md
@@ -652,10 +652,8 @@ Sends notifications to your users
 ```python
 import onesignal
 from onesignal.api import default_api
-from onesignal.model.rate_limit_error import RateLimitError
-from onesignal.model.generic_error import GenericError
+from onesignal.model.language_string_map import LanguageStringMap
 from onesignal.model.notification import Notification
-from onesignal.model.create_notification_success_response import CreateNotificationSuccessResponse
 from pprint import pprint
 
 # See configuration.py for a list of all supported configuration parameters.
@@ -667,21 +665,23 @@ configuration = onesignal.Configuration(
 )
 
 
-# Enter a context with an instance of the API client
 with onesignal.ApiClient(configuration) as api_client:
-    # Create an instance of the API class
     api_instance = default_api.DefaultApi(api_client)
-    notification = Notification(None) 
-
-    # example passing only required values which don't have defaults set
+    notification = Notification(
+        app_id='YOUR_APP_ID',
+        contents=LanguageStringMap(en='Hello from OneSignal!'),
+        include_aliases={'external_id': ['YOUR_USER_EXTERNAL_ID']},
+        target_channel='push',
+    )
     try:
-        # Create notification
         api_response = api_instance.create_notification(notification)
-        pprint(api_response)
+        if not api_response.id:
+            print('Notification was not created:', api_response.errors)
+        else:
+            pprint(api_response)
     except onesignal.ApiException as e:
-        print("Exception when calling DefaultApi->create_notification: %s\n" % e)
+        print('Exception when calling DefaultApi->create_notification: %s\n' % e)
 ```
-
 
 ### Parameters
 


### PR DESCRIPTION
## Release v5.4.0

### 🚀 Features
- feat(ci): close stale user-api-updates PRs before fan-out
- feat: add flat create-notification doc examples via vendor extension

### 🐛 Bug Fixes
- fix(ruby): remove redundant gem build step from release workflow
- fix(ci): tolerate gh pr close failures during stale PR cleanup
- fix: Rust consumer imports, Python model imports, Java modelPackage in API docs
- fix(ci): drift-mode rerun safety + pre-release range matching

### 📚 Docs
- docs: point partial-release caveat at SDK-4396 (cd.yml scope filter)

### 🔧 Internal
- build(release): bump package versions
- test(ruby): use string outer / symbol inner keys for result.content
- build(ruby): sync release workflow fix
- ci: generate real release notes in downstream PR bodies
- ci: correct release-notes anchor + warn on compareCommits truncation
- ci: add script/bump-version helper
- ci: auto-populate root release PR body via sdk-shared/create-release.yml
- ci: add one-click release orchestrator via sdk-shared/prep-release.yml
- ci: unstage devdist's pre-staged outputs deletions before chore commit
- ci: delegate release version math to node-semver CLI
- ci: enforce lockstep versioning across all client libraries
- ci: add partial-release label bypass + document per-language hotfix flow
- ci: gate release workflow on script/test-<lang> matrix
- ci: pin release test matrix checkouts to rel/<version>
- ci: cut root GitHub Release on every release PR merge
- ci: anchor downstream-links version on commit message, not api.json
- ci: harden downstream-links gate, reconcile bare-version tags, make re-runs idempotent
- ci: auto-transition Linear tickets to Deployed on release
- ci: tighten lint-pr-title.yml to align with sdk-shared conventions
- ci: scope cd.yml fan-out to changed outputs/<lang>/ trees
- ci: address PR #364 review feedback
- ci: support drift-preserving releases (per-library version bumps)
- build: sync generated SDKs and DefaultApi reference docs
- build: refresh DefaultApi.md for Java, Python, and Rust

---
_Generated from [OneSignal/api-client-libraries@bc71af6...8a77f63](https://github.com/OneSignal/api-client-libraries/compare/bc71af602529f22c0d442e3b60e585fb0ad14264...8a77f63491b3d6c70b21ab49e189efca93ed6833)._