### PR TITLE
docs: improve DefaultApi.md examples and add common-patterns preamble

### DIFF
--- a/docs/DefaultApi.md
+++ b/docs/DefaultApi.md
@@ -50,6 +50,34 @@ Method | HTTP request | Description
 [**view_templates**](DefaultApi.md#view_templates) | **GET** /templates | View templates
 
 
+## Common patterns
+
+The per-endpoint examples below illustrate one specific call each. This section covers patterns that apply to most operations.
+
+### Authentication
+
+Every operation requires either a **REST API Key** (App-scoped, used by ~77% of endpoints) or an **Organization API Key** (used by the remaining ~23% — the app-management endpoints `get_apps` / `create_app` / `get_app` / `update_app` / `copy_template_to_app`, plus the API-key administration endpoints `view_api_keys` / `create_api_key` / `delete_api_key` / `update_api_key` / `rotate_api_key`). The two are not interchangeable. The "Authorization" row on each endpoint below lists the exact scheme.
+
+### Idempotency
+
+`POST /notifications` accepts a top-level `idempotency_key` (UUIDv4) that the server uses for request dedup within a **30-day window**. Pass a freshly-generated UUID per logical send so that network-level retries are safe. Never reuse a key across distinct sends — the server returns the original response instead of acting on the new payload. The hero `create_notification` example below demonstrates the call.
+
+### Error handling
+
+When a request fails, the SDK raises `onesignal.ApiException`. The HTTP status code is `e.status` (int); the parsed error body is `e.body`. Most envelopes match `{"errors": ["..."]}` (an array of strings) but a few endpoints return `{"errors": [{"code": ..., "title": ..., "meta": {...}}]}` (an array of structured error objects — used by `POST /apps/{app_id}/users` 409 conflict, see `CreateUserConflictResponse`), `{"errors": "..."}` (string), or `{"success": False}` (no `errors` field at all). Robust error-handling code should tolerate all four shapes.
+
+### Polymorphic 200 from POST /notifications
+
+`CreateNotificationSuccessResponse` has two distinct shapes that share the same schema; branch on `id`:
+- **Success** — `id` is a non-empty UUID. `errors`, if present, is an object keyed by recipient-identifier type (`invalid_player_ids`, `invalid_external_user_ids`, `invalid_aliases`, ...) listing recipients that were skipped (partial-success path).
+- **No-send** — `id` is the empty string `""`. `errors` is a string array with the sentinel reason, typically `["All included players are not subscribed"]`.
+
+The hero `create_notification` example below demonstrates the branch pattern explicitly.
+
+### Targeting users by External ID
+
+Set `include_aliases.external_id` to a list of External IDs and set `target_channel` to `push` / `email` / `sms`. The alias label must be the literal string `external_id` — camelCase variants such as `externalId` are silently ignored and yield zero recipients. **Do not confuse** this with the deprecated top-level `external_id` notification field — a separate correlation/idempotency field with its own 30-day dedup keyspace (parallel to `idempotency_key`, not an alias) and no targeting effect.
+
 # **cancel_notification**
 > GenericSuccessBoolResponse cancel_notification(app_id, notification_id)
 
@@ -82,8 +110,8 @@ configuration = onesignal.Configuration(
 with onesignal.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = default_api.DefaultApi(api_client)
-    app_id = "app_id_example" 
-    notification_id = "notification_id_example" 
+    app_id = "00000000-0000-0000-0000-000000000000" 
+    notification_id = "b3a0c8bd-3a4c-4b22-9a73-3f1a8c2d1b88" 
 
     # example passing only required values which don't have defaults set
     try:
@@ -92,6 +120,8 @@ with onesignal.ApiClient(configuration) as api_client:
         pprint(api_response)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->cancel_notification: %s\n" % e)
+        print("Status Code: %s" % e.status)
+        print("Response Body: %s" % e.body)
 ```
 
 
@@ -159,8 +189,8 @@ configuration = onesignal.Configuration(
 with onesignal.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = default_api.DefaultApi(api_client)
-    template_id = "template_id_example" 
-    app_id = "app_id_example" 
+    template_id = "e4d3c2b1-a09f-4f1e-8d7c-6b5a4f3e2d1c" 
+    app_id = "00000000-0000-0000-0000-000000000000" 
     copy_template_request = CopyTemplateRequest(
         target_app_id="target_app_id_example",
     ) 
@@ -172,6 +202,8 @@ with onesignal.ApiClient(configuration) as api_client:
         pprint(api_response)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->copy_template_to_app: %s\n" % e)
+        print("Status Code: %s" % e.status)
+        print("Response Body: %s" % e.body)
 ```
 
 
@@ -238,9 +270,9 @@ configuration = onesignal.Configuration(
 with onesignal.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = default_api.DefaultApi(api_client)
-    app_id = "app_id_example" 
-    alias_label = "alias_label_example" 
-    alias_id = "alias_id_example" 
+    app_id = "00000000-0000-0000-0000-000000000000" 
+    alias_label = "external_id" 
+    alias_id = "YOUR_USER_EXTERNAL_ID" 
     user_identity_body = UserIdentityBody(
         identity=IdentityObject(
             key="key_example",
@@ -253,6 +285,8 @@ with onesignal.ApiClient(configuration) as api_client:
         pprint(api_response)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->create_alias: %s\n" % e)
+        print("Status Code: %s" % e.status)
+        print("Response Body: %s" % e.body)
 ```
 
 
@@ -323,8 +357,8 @@ configuration = onesignal.Configuration(
 with onesignal.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = default_api.DefaultApi(api_client)
-    app_id = "app_id_example" 
-    subscription_id = "subscription_id_example" 
+    app_id = "00000000-0000-0000-0000-000000000000" 
+    subscription_id = "7e4c5b9a-1f60-4d07-9b1a-2e8c8d2cae51" 
     user_identity_body = UserIdentityBody(
         identity=IdentityObject(
             key="key_example",
@@ -337,6 +371,8 @@ with onesignal.ApiClient(configuration) as api_client:
         pprint(api_response)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->create_alias_by_subscription: %s\n" % e)
+        print("Status Code: %s" % e.status)
+        print("Response Body: %s" % e.body)
 ```
 
 
@@ -406,7 +442,7 @@ configuration = onesignal.Configuration(
 with onesignal.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = default_api.DefaultApi(api_client)
-    app_id = "app_id_example" 
+    app_id = "00000000-0000-0000-0000-000000000000" 
     create_api_key_request = CreateApiKeyRequest(
         name="name_example",
         ip_allowlist_mode="disabled",
@@ -422,6 +458,8 @@ with onesignal.ApiClient(configuration) as api_client:
         pprint(api_response)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->create_api_key: %s\n" % e)
+        print("Status Code: %s" % e.status)
+        print("Response Body: %s" % e.body)
 ```
 
 
@@ -518,6 +556,8 @@ with onesignal.ApiClient(configuration) as api_client:
         pprint(api_response)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->create_app: %s\n" % e)
+        print("Status Code: %s" % e.status)
+        print("Response Body: %s" % e.body)
 ```
 
 
@@ -583,7 +623,7 @@ configuration = onesignal.Configuration(
 with onesignal.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = default_api.DefaultApi(api_client)
-    app_id = "app_id_example" # Your OneSignal App ID in UUID v4 format. 
+    app_id = "00000000-0000-0000-0000-000000000000" # Your OneSignal App ID in UUID v4 format. 
     custom_events_request = CustomEventsRequest(
         events=[
             CustomEvent(
@@ -603,6 +643,8 @@ with onesignal.ApiClient(configuration) as api_client:
         pprint(api_response)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->create_custom_events: %s\n" % e)
+        print("Status Code: %s" % e.status)
+        print("Response Body: %s" % e.body)
 ```
 
 
@@ -650,11 +692,11 @@ Sends notifications to your users.  **Target by External ID (push example):** se
 * Bearer Authentication (rest_api_key):
 
 ```python
+import uuid
 import onesignal
 from onesignal.api import default_api
 from onesignal.model.language_string_map import LanguageStringMap
 from onesignal.model.notification import Notification
-from pprint import pprint
 
 # See configuration.py for a list of all supported configuration parameters.
 # Some of the OneSignal endpoints require ORGANIZATION_API_KEY token for authorization, while others require REST_API_KEY.
@@ -672,15 +714,36 @@ with onesignal.ApiClient(configuration) as api_client:
         contents=LanguageStringMap(en='Hello from OneSignal!'),
         include_aliases={'external_id': ['YOUR_USER_EXTERNAL_ID']},
         target_channel='push',
+        # Idempotency key: a client-generated UUID that lets you safely retry on network
+        # failure. If two requests arrive with the same key inside the 30-day window, only
+        # the first is sent and the second returns the original response. Use uuid.uuid4()
+        # or a similar source of randomness — DO NOT reuse keys across logically distinct
+        # sends.
+        idempotency_key=str(uuid.uuid4()),
     )
     try:
         api_response = api_instance.create_notification(notification)
-        if not api_response.id:
-            print('Notification was not created:', api_response.errors)
+        # `api_response.id` discriminates the two HTTP 200 shapes. A falsy value means no
+        # notification was created (e.g. all targets were unreachable / not subscribed).
+        # `api_response.errors` is polymorphic: a `list[str]` in the no-subscribers case, or
+        # a dict keyed by recipient-identifier type (`invalid_player_ids`,
+        # `invalid_external_user_ids`, `invalid_aliases`, ...) when the notification WAS
+        # created but some recipients were skipped. Access via `.get('errors')` rather than
+        # attribute access — the legacy Python generator's `ModelNormal.__getattr__` raises
+        # `ApiAttributeError` for optional fields that the server omitted, so plain
+        # `api_response.errors` would crash on the pure-success path.
+        response_id = api_response.get('id')
+        response_errors = api_response.get('errors')
+        if not response_id:
+            print('Notification was not sent:', response_errors)
+        elif response_errors:
+            print('Notification created:', response_id, '(partial failures:', response_errors, ')')
         else:
-            pprint(api_response)
+            print('Notification created:', response_id)
     except onesignal.ApiException as e:
         print('Exception when calling DefaultApi->create_notification: %s\n' % e)
+        print('Status Code: %s' % e.status)
+        print('Response Body: %s' % e.body)
 ```
 
 ### Parameters
@@ -747,7 +810,7 @@ configuration = onesignal.Configuration(
 with onesignal.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = default_api.DefaultApi(api_client)
-    app_id = "app_id_example" # The OneSignal App ID for your app.  Available in Keys & IDs. 
+    app_id = "00000000-0000-0000-0000-000000000000" # The OneSignal App ID for your app.  Available in Keys & IDs. 
     segment = Segment(
         id="id_example",
         name="name_example",
@@ -763,6 +826,8 @@ with onesignal.ApiClient(configuration) as api_client:
         pprint(api_response)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->create_segment: %s\n" % e)
+        print("Status Code: %s" % e.status)
+        print("Response Body: %s" % e.body)
 
     # example passing only required values which don't have defaults set
     # and optional values
@@ -772,6 +837,8 @@ with onesignal.ApiClient(configuration) as api_client:
         pprint(api_response)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->create_segment: %s\n" % e)
+        print("Status Code: %s" % e.status)
+        print("Response Body: %s" % e.body)
 ```
 
 
@@ -839,9 +906,9 @@ configuration = onesignal.Configuration(
 with onesignal.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = default_api.DefaultApi(api_client)
-    app_id = "app_id_example" 
-    alias_label = "alias_label_example" 
-    alias_id = "alias_id_example" 
+    app_id = "00000000-0000-0000-0000-000000000000" 
+    alias_label = "external_id" 
+    alias_id = "YOUR_USER_EXTERNAL_ID" 
     subscription_body = SubscriptionBody(
         subscription=Subscription(
             id="id_example",
@@ -870,6 +937,8 @@ with onesignal.ApiClient(configuration) as api_client:
         pprint(api_response)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->create_subscription: %s\n" % e)
+        print("Status Code: %s" % e.status)
+        print("Response Body: %s" % e.body)
 ```
 
 
@@ -1096,6 +1165,8 @@ with onesignal.ApiClient(configuration) as api_client:
         pprint(api_response)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->create_template: %s\n" % e)
+        print("Status Code: %s" % e.status)
+        print("Response Body: %s" % e.body)
 ```
 
 
@@ -1162,7 +1233,7 @@ configuration = onesignal.Configuration(
 with onesignal.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = default_api.DefaultApi(api_client)
-    app_id = "app_id_example" 
+    app_id = "00000000-0000-0000-0000-000000000000" 
     user = User(
         properties=PropertiesObject(
             tags={},
@@ -1216,6 +1287,8 @@ with onesignal.ApiClient(configuration) as api_client:
         pprint(api_response)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->create_user: %s\n" % e)
+        print("Status Code: %s" % e.status)
+        print("Response Body: %s" % e.body)
 ```
 
 
@@ -1285,10 +1358,10 @@ configuration = onesignal.Configuration(
 with onesignal.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = default_api.DefaultApi(api_client)
-    app_id = "app_id_example" 
-    alias_label = "alias_label_example" 
-    alias_id = "alias_id_example" 
-    alias_label_to_delete = "alias_label_to_delete_example" 
+    app_id = "00000000-0000-0000-0000-000000000000" 
+    alias_label = "external_id" 
+    alias_id = "YOUR_USER_EXTERNAL_ID" 
+    alias_label_to_delete = "external_id" 
 
     # example passing only required values which don't have defaults set
     try:
@@ -1296,6 +1369,8 @@ with onesignal.ApiClient(configuration) as api_client:
         pprint(api_response)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->delete_alias: %s\n" % e)
+        print("Status Code: %s" % e.status)
+        print("Response Body: %s" % e.body)
 ```
 
 
@@ -1364,8 +1439,8 @@ configuration = onesignal.Configuration(
 with onesignal.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = default_api.DefaultApi(api_client)
-    app_id = "app_id_example" 
-    token_id = "token_id_example" 
+    app_id = "00000000-0000-0000-0000-000000000000" 
+    token_id = "0aa1b2c3-d4e5-46f7-8899-aabbccddeeff" 
 
     # example passing only required values which don't have defaults set
     try:
@@ -1374,6 +1449,8 @@ with onesignal.ApiClient(configuration) as api_client:
         pprint(api_response)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->delete_api_key: %s\n" % e)
+        print("Status Code: %s" % e.status)
+        print("Response Body: %s" % e.body)
 ```
 
 
@@ -1439,8 +1516,8 @@ configuration = onesignal.Configuration(
 with onesignal.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = default_api.DefaultApi(api_client)
-    app_id = "app_id_example" # The OneSignal App ID for your app.  Available in Keys & IDs. 
-    segment_id = "segment_id_example" # The segment_id can be found in the URL of the segment when viewing it in the dashboard. 
+    app_id = "00000000-0000-0000-0000-000000000000" # The OneSignal App ID for your app.  Available in Keys & IDs. 
+    segment_id = "d6c5a3e1-9f17-44a1-9d10-7c0e4a2b1c8e" # The segment_id can be found in the URL of the segment when viewing it in the dashboard. 
 
     # example passing only required values which don't have defaults set
     try:
@@ -1449,6 +1526,8 @@ with onesignal.ApiClient(configuration) as api_client:
         pprint(api_response)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->delete_segment: %s\n" % e)
+        print("Status Code: %s" % e.status)
+        print("Response Body: %s" % e.body)
 ```
 
 
@@ -1515,14 +1594,16 @@ configuration = onesignal.Configuration(
 with onesignal.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = default_api.DefaultApi(api_client)
-    app_id = "app_id_example" 
-    subscription_id = "subscription_id_example" 
+    app_id = "00000000-0000-0000-0000-000000000000" 
+    subscription_id = "7e4c5b9a-1f60-4d07-9b1a-2e8c8d2cae51" 
 
     # example passing only required values which don't have defaults set
     try:
         api_instance.delete_subscription(app_id, subscription_id)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->delete_subscription: %s\n" % e)
+        print("Status Code: %s" % e.status)
+        print("Response Body: %s" % e.body)
 ```
 
 
@@ -1590,8 +1671,8 @@ configuration = onesignal.Configuration(
 with onesignal.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = default_api.DefaultApi(api_client)
-    template_id = "template_id_example" 
-    app_id = "app_id_example" 
+    template_id = "e4d3c2b1-a09f-4f1e-8d7c-6b5a4f3e2d1c" 
+    app_id = "00000000-0000-0000-0000-000000000000" 
 
     # example passing only required values which don't have defaults set
     try:
@@ -1600,6 +1681,8 @@ with onesignal.ApiClient(configuration) as api_client:
         pprint(api_response)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->delete_template: %s\n" % e)
+        print("Status Code: %s" % e.status)
+        print("Response Body: %s" % e.body)
 ```
 
 
@@ -1665,15 +1748,17 @@ configuration = onesignal.Configuration(
 with onesignal.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = default_api.DefaultApi(api_client)
-    app_id = "app_id_example" 
-    alias_label = "alias_label_example" 
-    alias_id = "alias_id_example" 
+    app_id = "00000000-0000-0000-0000-000000000000" 
+    alias_label = "external_id" 
+    alias_id = "YOUR_USER_EXTERNAL_ID" 
 
     # example passing only required values which don't have defaults set
     try:
         api_instance.delete_user(app_id, alias_label, alias_id)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->delete_user: %s\n" % e)
+        print("Status Code: %s" % e.status)
+        print("Response Body: %s" % e.body)
 ```
 
 
@@ -1742,8 +1827,8 @@ configuration = onesignal.Configuration(
 with onesignal.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = default_api.DefaultApi(api_client)
-    notification_id = "notification_id_example" # The ID of the notification to export events from. 
-    app_id = "app_id_example" # The ID of the app that the notification belongs to. 
+    notification_id = "b3a0c8bd-3a4c-4b22-9a73-3f1a8c2d1b88" # The ID of the notification to export events from. 
+    app_id = "00000000-0000-0000-0000-000000000000" # The ID of the app that the notification belongs to. 
 
     # example passing only required values which don't have defaults set
     try:
@@ -1752,6 +1837,8 @@ with onesignal.ApiClient(configuration) as api_client:
         pprint(api_response)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->export_events: %s\n" % e)
+        print("Status Code: %s" % e.status)
+        print("Response Body: %s" % e.body)
 ```
 
 
@@ -1820,7 +1907,7 @@ configuration = onesignal.Configuration(
 with onesignal.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = default_api.DefaultApi(api_client)
-    app_id = "app_id_example" # The app ID that you want to export devices from 
+    app_id = "00000000-0000-0000-0000-000000000000" # The app ID that you want to export devices from 
     export_subscriptions_request_body = ExportSubscriptionsRequestBody(
         extra_fields=[
             "extra_fields_example",
@@ -1836,6 +1923,8 @@ with onesignal.ApiClient(configuration) as api_client:
         pprint(api_response)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->export_subscriptions: %s\n" % e)
+        print("Status Code: %s" % e.status)
+        print("Response Body: %s" % e.body)
 
     # example passing only required values which don't have defaults set
     # and optional values
@@ -1845,6 +1934,8 @@ with onesignal.ApiClient(configuration) as api_client:
         pprint(api_response)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->export_subscriptions: %s\n" % e)
+        print("Status Code: %s" % e.status)
+        print("Response Body: %s" % e.body)
 ```
 
 
@@ -1911,9 +2002,9 @@ configuration = onesignal.Configuration(
 with onesignal.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = default_api.DefaultApi(api_client)
-    app_id = "app_id_example" 
-    alias_label = "alias_label_example" 
-    alias_id = "alias_id_example" 
+    app_id = "00000000-0000-0000-0000-000000000000" 
+    alias_label = "external_id" 
+    alias_id = "YOUR_USER_EXTERNAL_ID" 
 
     # example passing only required values which don't have defaults set
     try:
@@ -1921,6 +2012,8 @@ with onesignal.ApiClient(configuration) as api_client:
         pprint(api_response)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->get_aliases: %s\n" % e)
+        print("Status Code: %s" % e.status)
+        print("Response Body: %s" % e.body)
 ```
 
 
@@ -1988,8 +2081,8 @@ configuration = onesignal.Configuration(
 with onesignal.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = default_api.DefaultApi(api_client)
-    app_id = "app_id_example" 
-    subscription_id = "subscription_id_example" 
+    app_id = "00000000-0000-0000-0000-000000000000" 
+    subscription_id = "7e4c5b9a-1f60-4d07-9b1a-2e8c8d2cae51" 
 
     # example passing only required values which don't have defaults set
     try:
@@ -1997,6 +2090,8 @@ with onesignal.ApiClient(configuration) as api_client:
         pprint(api_response)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->get_aliases_by_subscription: %s\n" % e)
+        print("Status Code: %s" % e.status)
+        print("Response Body: %s" % e.body)
 ```
 
 
@@ -2063,7 +2158,7 @@ configuration = onesignal.Configuration(
 with onesignal.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = default_api.DefaultApi(api_client)
-    app_id = "app_id_example" # An app id 
+    app_id = "00000000-0000-0000-0000-000000000000" # An app id 
 
     # example passing only required values which don't have defaults set
     try:
@@ -2072,6 +2167,8 @@ with onesignal.ApiClient(configuration) as api_client:
         pprint(api_response)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->get_app: %s\n" % e)
+        print("Status Code: %s" % e.status)
+        print("Response Body: %s" % e.body)
 ```
 
 
@@ -2145,6 +2242,8 @@ with onesignal.ApiClient(configuration) as api_client:
         pprint(api_response)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->get_apps: %s\n" % e)
+        print("Status Code: %s" % e.status)
+        print("Response Body: %s" % e.body)
 ```
 
 
@@ -2207,8 +2306,8 @@ configuration = onesignal.Configuration(
 with onesignal.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = default_api.DefaultApi(api_client)
-    app_id = "app_id_example" 
-    notification_id = "notification_id_example" 
+    app_id = "00000000-0000-0000-0000-000000000000" 
+    notification_id = "b3a0c8bd-3a4c-4b22-9a73-3f1a8c2d1b88" 
 
     # example passing only required values which don't have defaults set
     try:
@@ -2217,6 +2316,8 @@ with onesignal.ApiClient(configuration) as api_client:
         pprint(api_response)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->get_notification: %s\n" % e)
+        print("Status Code: %s" % e.status)
+        print("Response Body: %s" % e.body)
 ```
 
 
@@ -2285,7 +2386,7 @@ configuration = onesignal.Configuration(
 with onesignal.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = default_api.DefaultApi(api_client)
-    notification_id = "notification_id_example" # The \"id\" of the message found in the Notification object 
+    notification_id = "b3a0c8bd-3a4c-4b22-9a73-3f1a8c2d1b88" # The \"id\" of the message found in the Notification object 
     get_notification_history_request_body = GetNotificationHistoryRequestBody(
         events="sent",
         email="email_example",
@@ -2299,6 +2400,8 @@ with onesignal.ApiClient(configuration) as api_client:
         pprint(api_response)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->get_notification_history: %s\n" % e)
+        print("Status Code: %s" % e.status)
+        print("Response Body: %s" % e.body)
 ```
 
 
@@ -2366,9 +2469,9 @@ configuration = onesignal.Configuration(
 with onesignal.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = default_api.DefaultApi(api_client)
-    app_id = "app_id_example" # The app ID that you want to view notifications from 
-    limit = 1  # How many notifications to return.  Max is 50.  Default is 50. (optional) 
-    offset = 1  # Page offset.  Default is 0.  Results are sorted by queued_at in descending order.  queued_at is a representation of the time that the notification was queued at. (optional) 
+    app_id = "00000000-0000-0000-0000-000000000000" # The app ID that you want to view notifications from 
+    limit = 10  # How many notifications to return.  Max is 50.  Default is 50. (optional) 
+    offset = 0  # Page offset.  Default is 0.  Results are sorted by queued_at in descending order.  queued_at is a representation of the time that the notification was queued at. (optional) 
     kind = 0  # Kind of notifications returned:   * unset - All notification types (default)   * `0` - Dashboard only   * `1` - API only   * `3` - Automated only  (optional) 
 
     # example passing only required values which don't have defaults set
@@ -2378,6 +2481,8 @@ with onesignal.ApiClient(configuration) as api_client:
         pprint(api_response)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->get_notifications: %s\n" % e)
+        print("Status Code: %s" % e.status)
+        print("Response Body: %s" % e.body)
 
     # example passing only required values which don't have defaults set
     # and optional values
@@ -2387,6 +2492,8 @@ with onesignal.ApiClient(configuration) as api_client:
         pprint(api_response)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->get_notifications: %s\n" % e)
+        print("Status Code: %s" % e.status)
+        print("Response Body: %s" % e.body)
 ```
 
 
@@ -2455,12 +2562,12 @@ configuration = onesignal.Configuration(
 with onesignal.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = default_api.DefaultApi(api_client)
-    app_id = "app_id_example" # The OneSignal App ID for your app.  Available in Keys & IDs. 
-    outcome_names = "outcome_names_example" # Required Comma-separated list of names and the value (sum/count) for the returned outcome data. Note: Clicks only support count aggregation. For out-of-the-box OneSignal outcomes such as click and session duration, please use the \"os\" prefix with two underscores. For other outcomes, please use the name specified by the user. Example:os__session_duration.count,os__click.count,CustomOutcomeName.sum  
-    outcome_names2 = "outcome_names[]_example"  # Optional If outcome names contain any commas, then please specify only one value at a time. Example: outcome_names[]=os__click.count&outcome_names[]=Sales, Purchase.count where \"Sales, Purchase\" is the custom outcomes with a comma in the name.  (optional) 
-    outcome_time_range = "outcome_time_range_example"  # Optional Time range for the returned data. The values can be 1h (for the last 1 hour data), 1d (for the last 1 day data), or 1mo (for the last 1 month data). Default is 1h if the parameter is omitted.  (optional) 
-    outcome_platforms = "outcome_platforms_example"  # Optional Platform id. Refer device's platform ids for values. Example: outcome_platform=0 for iOS outcome_platform=7,8 for Safari and Firefox Default is data from all platforms if the parameter is omitted.  (optional) 
-    outcome_attribution = "outcome_attribution_example"  # Optional Attribution type for the outcomes. The values can be direct or influenced or unattributed. Example: outcome_attribution=direct Default is total (returns direct+influenced+unattributed) if the parameter is omitted.  (optional) 
+    app_id = "00000000-0000-0000-0000-000000000000" # The OneSignal App ID for your app.  Available in Keys & IDs. 
+    outcome_names = "os__session_duration.count,os__click.count" # Required Comma-separated list of names and the value (sum/count) for the returned outcome data. Note: Clicks only support count aggregation. For out-of-the-box OneSignal outcomes such as click and session duration, please use the \"os\" prefix with two underscores. For other outcomes, please use the name specified by the user. Example:os__session_duration.count,os__click.count,CustomOutcomeName.sum  
+    outcome_names2 = "os__session_duration.count"  # Optional If outcome names contain any commas, then please specify only one value at a time. Example: outcome_names[]=os__click.count&outcome_names[]=Sales, Purchase.count where \"Sales, Purchase\" is the custom outcomes with a comma in the name.  (optional) 
+    outcome_time_range = "1d"  # Optional Time range for the returned data. The values can be 1h (for the last 1 hour data), 1d (for the last 1 day data), or 1mo (for the last 1 month data). Default is 1h if the parameter is omitted.  (optional) 
+    outcome_platforms = "0,1"  # Optional Platform id. Refer device's platform ids for values. Example: outcome_platform=0 for iOS outcome_platform=7,8 for Safari and Firefox Default is data from all platforms if the parameter is omitted.  (optional) 
+    outcome_attribution = "direct"  # Optional Attribution type for the outcomes. The values can be direct or influenced or unattributed. Example: outcome_attribution=direct Default is total (returns direct+influenced+unattributed) if the parameter is omitted.  (optional) 
 
     # example passing only required values which don't have defaults set
     try:
@@ -2469,6 +2576,8 @@ with onesignal.ApiClient(configuration) as api_client:
         pprint(api_response)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->get_outcomes: %s\n" % e)
+        print("Status Code: %s" % e.status)
+        print("Response Body: %s" % e.body)
 
     # example passing only required values which don't have defaults set
     # and optional values
@@ -2478,6 +2587,8 @@ with onesignal.ApiClient(configuration) as api_client:
         pprint(api_response)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->get_outcomes: %s\n" % e)
+        print("Status Code: %s" % e.status)
+        print("Response Body: %s" % e.body)
 ```
 
 
@@ -2548,9 +2659,9 @@ configuration = onesignal.Configuration(
 with onesignal.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = default_api.DefaultApi(api_client)
-    app_id = "app_id_example" # The OneSignal App ID for your app.  Available in Keys & IDs. 
-    offset = 1  # Segments are listed in ascending order of created_at date. offset will omit that number of segments from the beginning of the list. Eg offset 5, will remove the 5 earliest created Segments. (optional) 
-    limit = 1  # The amount of Segments in the response. Maximum 300. (optional) 
+    app_id = "00000000-0000-0000-0000-000000000000" # The OneSignal App ID for your app.  Available in Keys & IDs. 
+    offset = 0  # Segments are listed in ascending order of created_at date. offset will omit that number of segments from the beginning of the list. Eg offset 5, will remove the 5 earliest created Segments. (optional) 
+    limit = 10  # The amount of Segments in the response. Maximum 300. (optional) 
 
     # example passing only required values which don't have defaults set
     try:
@@ -2559,6 +2670,8 @@ with onesignal.ApiClient(configuration) as api_client:
         pprint(api_response)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->get_segments: %s\n" % e)
+        print("Status Code: %s" % e.status)
+        print("Response Body: %s" % e.body)
 
     # example passing only required values which don't have defaults set
     # and optional values
@@ -2568,6 +2681,8 @@ with onesignal.ApiClient(configuration) as api_client:
         pprint(api_response)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->get_segments: %s\n" % e)
+        print("Status Code: %s" % e.status)
+        print("Response Body: %s" % e.body)
 ```
 
 
@@ -2635,9 +2750,9 @@ configuration = onesignal.Configuration(
 with onesignal.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = default_api.DefaultApi(api_client)
-    app_id = "app_id_example" 
-    alias_label = "alias_label_example" 
-    alias_id = "alias_id_example" 
+    app_id = "00000000-0000-0000-0000-000000000000" 
+    alias_label = "external_id" 
+    alias_id = "YOUR_USER_EXTERNAL_ID" 
 
     # example passing only required values which don't have defaults set
     try:
@@ -2645,6 +2760,8 @@ with onesignal.ApiClient(configuration) as api_client:
         pprint(api_response)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->get_user: %s\n" % e)
+        print("Status Code: %s" % e.status)
+        print("Response Body: %s" % e.body)
 ```
 
 
@@ -2712,8 +2829,8 @@ configuration = onesignal.Configuration(
 with onesignal.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = default_api.DefaultApi(api_client)
-    app_id = "app_id_example" 
-    token_id = "token_id_example" 
+    app_id = "00000000-0000-0000-0000-000000000000" 
+    token_id = "0aa1b2c3-d4e5-46f7-8899-aabbccddeeff" 
 
     # example passing only required values which don't have defaults set
     try:
@@ -2722,6 +2839,8 @@ with onesignal.ApiClient(configuration) as api_client:
         pprint(api_response)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->rotate_api_key: %s\n" % e)
+        print("Status Code: %s" % e.status)
+        print("Response Body: %s" % e.body)
 ```
 
 
@@ -2788,8 +2907,8 @@ configuration = onesignal.Configuration(
 with onesignal.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = default_api.DefaultApi(api_client)
-    app_id = "app_id_example" # Your OneSignal App ID in UUID v4 format. 
-    activity_type = "activity_type_example" # The name of the Live Activity defined in your app. This should match the attributes struct used in your app's Live Activity implementation. 
+    app_id = "00000000-0000-0000-0000-000000000000" # Your OneSignal App ID in UUID v4 format. 
+    activity_type = "order_status" # The name of the Live Activity defined in your app. This should match the attributes struct used in your app's Live Activity implementation. 
     start_live_activity_request = StartLiveActivityRequest(
         name="name_example",
         event="start",
@@ -2916,6 +3035,8 @@ with onesignal.ApiClient(configuration) as api_client:
         pprint(api_response)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->start_live_activity: %s\n" % e)
+        print("Status Code: %s" % e.status)
+        print("Response Body: %s" % e.body)
 ```
 
 
@@ -2984,8 +3105,8 @@ configuration = onesignal.Configuration(
 with onesignal.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = default_api.DefaultApi(api_client)
-    app_id = "app_id_example" 
-    subscription_id = "subscription_id_example" 
+    app_id = "00000000-0000-0000-0000-000000000000" 
+    subscription_id = "7e4c5b9a-1f60-4d07-9b1a-2e8c8d2cae51" 
     transfer_subscription_request_body = TransferSubscriptionRequestBody(
         identity={
             "key": "key_example",
@@ -2998,6 +3119,8 @@ with onesignal.ApiClient(configuration) as api_client:
         pprint(api_response)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->transfer_subscription: %s\n" % e)
+        print("Status Code: %s" % e.status)
+        print("Response Body: %s" % e.body)
 ```
 
 
@@ -3067,9 +3190,9 @@ configuration = onesignal.Configuration(
 with onesignal.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = default_api.DefaultApi(api_client)
-    app_id = "app_id_example" # The OneSignal App ID for your app.  Available in Keys & IDs. 
-    notification_id = "notification_id_example" # The id of the message found in the creation notification POST response, View Notifications GET response, or URL within the Message Report. 
-    token = "token_example" # The unsubscribe token that is generated via liquid syntax in {{subscription.unsubscribe_token}} when personalizing an email. 
+    app_id = "00000000-0000-0000-0000-000000000000" # The OneSignal App ID for your app.  Available in Keys & IDs. 
+    notification_id = "b3a0c8bd-3a4c-4b22-9a73-3f1a8c2d1b88" # The id of the message found in the creation notification POST response, View Notifications GET response, or URL within the Message Report. 
+    token = "YOUR_TOKEN_ID" # The unsubscribe token that is generated via liquid syntax in {{subscription.unsubscribe_token}} when personalizing an email. 
 
     # example passing only required values which don't have defaults set
     try:
@@ -3078,6 +3201,8 @@ with onesignal.ApiClient(configuration) as api_client:
         pprint(api_response)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->unsubscribe_email_with_token: %s\n" % e)
+        print("Status Code: %s" % e.status)
+        print("Response Body: %s" % e.body)
 ```
 
 
@@ -3144,8 +3269,8 @@ configuration = onesignal.Configuration(
 with onesignal.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = default_api.DefaultApi(api_client)
-    app_id = "app_id_example" 
-    token_id = "token_id_example" 
+    app_id = "00000000-0000-0000-0000-000000000000" 
+    token_id = "0aa1b2c3-d4e5-46f7-8899-aabbccddeeff" 
     update_api_key_request = UpdateApiKeyRequest(
         name="name_example",
         ip_allowlist_mode="disabled",
@@ -3161,6 +3286,8 @@ with onesignal.ApiClient(configuration) as api_client:
         pprint(api_response)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->update_api_key: %s\n" % e)
+        print("Status Code: %s" % e.status)
+        print("Response Body: %s" % e.body)
 ```
 
 
@@ -3227,7 +3354,7 @@ configuration = onesignal.Configuration(
 with onesignal.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = default_api.DefaultApi(api_client)
-    app_id = "app_id_example" # An app id 
+    app_id = "00000000-0000-0000-0000-000000000000" # An app id 
     app = App(
         name="name_example",
         android_gcm_sender_id="android_gcm_sender_id_example",
@@ -3259,6 +3386,8 @@ with onesignal.ApiClient(configuration) as api_client:
         pprint(api_response)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->update_app: %s\n" % e)
+        print("Status Code: %s" % e.status)
+        print("Response Body: %s" % e.body)
 ```
 
 
@@ -3326,8 +3455,8 @@ configuration = onesignal.Configuration(
 with onesignal.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = default_api.DefaultApi(api_client)
-    app_id = "app_id_example" # The OneSignal App ID for your app.  Available in Keys & IDs. 
-    activity_id = "activity_id_example" # Live Activity record ID 
+    app_id = "00000000-0000-0000-0000-000000000000" # The OneSignal App ID for your app.  Available in Keys & IDs. 
+    activity_id = "12345" # Live Activity record ID 
     update_live_activity_request = UpdateLiveActivityRequest(
         name="name_example",
         event="update",
@@ -3435,6 +3564,8 @@ with onesignal.ApiClient(configuration) as api_client:
         pprint(api_response)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->update_live_activity: %s\n" % e)
+        print("Status Code: %s" % e.status)
+        print("Response Body: %s" % e.body)
 ```
 
 
@@ -3502,8 +3633,8 @@ configuration = onesignal.Configuration(
 with onesignal.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = default_api.DefaultApi(api_client)
-    app_id = "app_id_example" 
-    subscription_id = "subscription_id_example" 
+    app_id = "00000000-0000-0000-0000-000000000000" 
+    subscription_id = "7e4c5b9a-1f60-4d07-9b1a-2e8c8d2cae51" 
     subscription_body = SubscriptionBody(
         subscription=Subscription(
             id="id_example",
@@ -3531,6 +3662,8 @@ with onesignal.ApiClient(configuration) as api_client:
         api_instance.update_subscription(app_id, subscription_id, subscription_body)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->update_subscription: %s\n" % e)
+        print("Status Code: %s" % e.status)
+        print("Response Body: %s" % e.body)
 ```
 
 
@@ -3599,9 +3732,9 @@ configuration = onesignal.Configuration(
 with onesignal.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = default_api.DefaultApi(api_client)
-    app_id = "app_id_example" # Your OneSignal App ID in UUID v4 format. 
-    token_type = "token_type_example" # The type of token to use when looking up the subscription. See Subscription Types. 
-    token = "token_example" # The value of the token to lookup by (e.g., email address, phone number). 
+    app_id = "00000000-0000-0000-0000-000000000000" # Your OneSignal App ID in UUID v4 format. 
+    token_type = "Email" # The type of token to use when looking up the subscription. See Subscription Types. 
+    token = "user@example.com" # The value of the token to lookup by (e.g., email address, phone number). 
     subscription_body = SubscriptionBody(
         subscription=Subscription(
             id="id_example",
@@ -3631,6 +3764,8 @@ with onesignal.ApiClient(configuration) as api_client:
         pprint(api_response)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->update_subscription_by_token: %s\n" % e)
+        print("Status Code: %s" % e.status)
+        print("Response Body: %s" % e.body)
 ```
 
 
@@ -3699,8 +3834,8 @@ configuration = onesignal.Configuration(
 with onesignal.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = default_api.DefaultApi(api_client)
-    template_id = "template_id_example" 
-    app_id = "app_id_example" 
+    template_id = "e4d3c2b1-a09f-4f1e-8d7c-6b5a4f3e2d1c" 
+    app_id = "00000000-0000-0000-0000-000000000000" 
     update_template_request = UpdateTemplateRequest(
         name="name_example",
         contents=LanguageStringMap(
@@ -3855,6 +3990,8 @@ with onesignal.ApiClient(configuration) as api_client:
         pprint(api_response)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->update_template: %s\n" % e)
+        print("Status Code: %s" % e.status)
+        print("Response Body: %s" % e.body)
 ```
 
 
@@ -3922,9 +4059,9 @@ configuration = onesignal.Configuration(
 with onesignal.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = default_api.DefaultApi(api_client)
-    app_id = "app_id_example" 
-    alias_label = "alias_label_example" 
-    alias_id = "alias_id_example" 
+    app_id = "00000000-0000-0000-0000-000000000000" 
+    alias_label = "external_id" 
+    alias_id = "YOUR_USER_EXTERNAL_ID" 
     update_user_request = UpdateUserRequest(
         properties=PropertiesObject(
             tags={},
@@ -3967,6 +4104,8 @@ with onesignal.ApiClient(configuration) as api_client:
         pprint(api_response)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->update_user: %s\n" % e)
+        print("Status Code: %s" % e.status)
+        print("Response Body: %s" % e.body)
 ```
 
 
@@ -4035,7 +4174,7 @@ configuration = onesignal.Configuration(
 with onesignal.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = default_api.DefaultApi(api_client)
-    app_id = "app_id_example" 
+    app_id = "00000000-0000-0000-0000-000000000000" 
 
     # example passing only required values which don't have defaults set
     try:
@@ -4044,6 +4183,8 @@ with onesignal.ApiClient(configuration) as api_client:
         pprint(api_response)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->view_api_keys: %s\n" % e)
+        print("Status Code: %s" % e.status)
+        print("Response Body: %s" % e.body)
 ```
 
 
@@ -4107,8 +4248,8 @@ configuration = onesignal.Configuration(
 with onesignal.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = default_api.DefaultApi(api_client)
-    template_id = "template_id_example" 
-    app_id = "app_id_example" 
+    template_id = "e4d3c2b1-a09f-4f1e-8d7c-6b5a4f3e2d1c" 
+    app_id = "00000000-0000-0000-0000-000000000000" 
 
     # example passing only required values which don't have defaults set
     try:
@@ -4117,6 +4258,8 @@ with onesignal.ApiClient(configuration) as api_client:
         pprint(api_response)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->view_template: %s\n" % e)
+        print("Status Code: %s" % e.status)
+        print("Response Body: %s" % e.body)
 ```
 
 
@@ -4183,8 +4326,8 @@ configuration = onesignal.Configuration(
 with onesignal.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = default_api.DefaultApi(api_client)
-    app_id = "app_id_example" # Your OneSignal App ID in UUID v4 format. 
-    limit = 50  # Maximum number of templates. Default and max is 50. (optional) 
+    app_id = "00000000-0000-0000-0000-000000000000" # Your OneSignal App ID in UUID v4 format. 
+    limit = 10  # Maximum number of templates. Default and max is 50. (optional) 
     offset = 0  # Pagination offset. (optional) 
     channel = "push"  # Filter by delivery channel. (optional) 
 
@@ -4195,6 +4338,8 @@ with onesignal.ApiClient(configuration) as api_client:
         pprint(api_response)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->view_templates: %s\n" % e)
+        print("Status Code: %s" % e.status)
+        print("Response Body: %s" % e.body)
 
     # example passing only required values which don't have defaults set
     # and optional values
@@ -4204,6 +4349,8 @@ with onesignal.ApiClient(configuration) as api_client:
         pprint(api_response)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->view_templates: %s\n" % e)
+        print("Status Code: %s" % e.status)
+        print("Response Body: %s" % e.body)
 ```
 
 


### PR DESCRIPTION
## Documentation updates

Improvements to the generated `DefaultApi.md` example snippets:

- New common-patterns preamble at the top of `DefaultApi.md` covering authentication coverage, request/response conventions, and the error-envelope shapes consumers should expect to handle.
- Every example snippet now includes an idiomatic `try`/`catch` (or equivalent) that logs the status code and response body, replacing the previous bare exception print.
- The `POST /notifications` hero snippet demonstrates idempotency-key generation for safe retries within the 30-day window.
- The `POST /notifications` snippet now demonstrates polymorphic response handling (Message Sent vs. Message Not Sent) instead of an unsafe single-shape access.
- Spec-level enrichment: every path and query parameter now carries a realistic `example:` value, so generated parameter snippets no longer fall back to `defaultValue` or first-enum-value placeholders.

---
_Generated from [OneSignal/api-client-libraries@3b35d43...6d24a5c](https://github.com/OneSignal/api-client-libraries/compare/3b35d4372e302d390c67858963e63339b93e15ae...6d24a5cc38b06383b22a67c8805228afbe38e2f9)._