### PR TITLE
feat: add v5.7.0 package updates

### DIFF
--- a/docs/CreateNotificationSuccessResponse.md
+++ b/docs/CreateNotificationSuccessResponse.md
@@ -4,7 +4,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**id** | **str** | Notification identifier when the request created a notification. An empty string means no notification was created; read `errors` for details (HTTP may still be 200). | [optional] 
+**id** | **str** | Notification identifier when the request created a notification. An empty string means no notification was created; read `errors` for details (HTTP may still be 200). All OneSignal server SDKs expose message-sent / message-not-sent narrowing helpers (named idiomatically per language — e.g. `isMessageSent`, `is_message_sent`, `message_sent?`); prefer them over comparing `id` directly. | [optional] 
 **external_id** | **str, none_type** | Optional correlation / idempotency-related value from the API response. This is not the end-user External ID used for targeting recipients (that lives under `include_aliases.external_id`). | [optional] 
 **errors** | **bool, date, datetime, dict, float, int, list, str, none_type** | Polymorphic field: may be an array of human-readable strings and/or an object (for example with `invalid_aliases`, `invalid_external_user_ids`, or `invalid_player_ids`) depending on the API response; HTTP may still be 200 with partial success. Typed SDKs model this loosely so both shapes deserialize. | [optional] 
 **any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]

--- a/onesignal/helpers.py
+++ b/onesignal/helpers.py
@@ -96,3 +96,30 @@ def create_notification_with_retry(api, notification, max_retries=3, base_delay=
         if delay > 0:
             time.sleep(delay)
         attempt += 1
+
+
+def is_message_sent(response):
+    """Return True when a POST /notifications 200 response is the "message
+    sent" branch -- a notification was created and ``id`` is a non-empty string.
+
+    POST /notifications returns 200 in two cases that share the
+    ``CreateNotificationSuccessResponse`` shape: a notification was created
+    (non-empty ``id``), or none was (empty ``id``, with ``errors`` carrying the
+    reason). Prefer this guard over inspecting ``id`` directly.
+
+    :param response: a ``CreateNotificationSuccessResponse``
+    :return: True if a notification was created
+    """
+    notification_id = getattr(response, 'id', None)
+    return isinstance(notification_id, str) and len(notification_id) > 0
+
+
+def is_message_not_sent(response):
+    """Return True when a POST /notifications 200 response is the "message not
+    sent" branch -- no notification was created (``id`` is absent or empty);
+    inspect ``errors`` for why.
+
+    :param response: a ``CreateNotificationSuccessResponse``
+    :return: True if no notification was created
+    """
+    return not is_message_sent(response)

--- a/onesignal/model/create_notification_success_response.py
+++ b/onesignal/model/create_notification_success_response.py
@@ -139,7 +139,7 @@ class CreateNotificationSuccessResponse(ModelNormal):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
-            id (str): Notification identifier when the request created a notification. An empty string means no notification was created; read `errors` for details (HTTP may still be 200).. [optional]  # noqa: E501
+            id (str): Notification identifier when the request created a notification. An empty string means no notification was created; read `errors` for details (HTTP may still be 200). All OneSignal server SDKs expose message-sent / message-not-sent narrowing helpers (named idiomatically per language — e.g. `isMessageSent`, `is_message_sent`, `message_sent?`); prefer them over comparing `id` directly.. [optional]  # noqa: E501
             external_id (str, none_type): Optional correlation / idempotency-related value from the API response. This is not the end-user External ID used for targeting recipients (that lives under `include_aliases.external_id`).. [optional]  # noqa: E501
             errors (bool, date, datetime, dict, float, int, list, str, none_type): Polymorphic field: may be an array of human-readable strings and/or an object (for example with `invalid_aliases`, `invalid_external_user_ids`, or `invalid_player_ids`) depending on the API response; HTTP may still be 200 with partial success. Typed SDKs model this loosely so both shapes deserialize.. [optional]  # noqa: E501
         """
@@ -227,7 +227,7 @@ class CreateNotificationSuccessResponse(ModelNormal):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
-            id (str): Notification identifier when the request created a notification. An empty string means no notification was created; read `errors` for details (HTTP may still be 200).. [optional]  # noqa: E501
+            id (str): Notification identifier when the request created a notification. An empty string means no notification was created; read `errors` for details (HTTP may still be 200). All OneSignal server SDKs expose message-sent / message-not-sent narrowing helpers (named idiomatically per language — e.g. `isMessageSent`, `is_message_sent`, `message_sent?`); prefer them over comparing `id` directly.. [optional]  # noqa: E501
             external_id (str, none_type): Optional correlation / idempotency-related value from the API response. This is not the end-user External ID used for targeting recipients (that lives under `include_aliases.external_id`).. [optional]  # noqa: E501
             errors (bool, date, datetime, dict, float, int, list, str, none_type): Polymorphic field: may be an array of human-readable strings and/or an object (for example with `invalid_aliases`, `invalid_external_user_ids`, or `invalid_player_ids`) depending on the API response; HTTP may still be 200 with partial success. Typed SDKs model this loosely so both shapes deserialize.. [optional]  # noqa: E501
         """


### PR DESCRIPTION
## Release v5.7.0

### 🚀 Features
- feat: [SDK-4440] generate typed error-code catalog module per SDK
- feat: [SDK-4441] add idempotency-key retry helper for create-notification
- feat: [SDK-4441] expose createNotificationWithRetry as a client method
- feat: [SDK-4441] clamp retry helper backoff base to [1s, 60s]
- feat: [SDK-4781] add message-sent/not-sent narrowing helpers
- feat: [SDK-4781] refine narrowing-helper doc nudge and PHP null-safety

### 🐛 Bug Fixes
- fix: [SDK-4440] reclassify OVER_SUBSCRIBER_LIMIT as a template entry
- fix: [SDK-4438] surface object-shaped errors in error-messages accessors
- fix: [SDK-4440] trim OneSignalErrors catalog to a verified minimal set

### 📚 Docs
- docs: [SDK-4441] add createNotificationWithRetry example to DefaultApi docs
- docs: [SDK-4440] fix OneSignalErrors usage example for the 200-status sentinel
- docs: clarify errorMessages excludes structured meta; show how to read it
- docs: demonstrate reading 409 conflict meta in CreateUser example
- docs: [SDK-4440] cross-link OneSignalErrors catalog from DefaultApi.md error handling

---
_Generated from [OneSignal/api-client-libraries@e4fc576...c73114f](https://github.com/OneSignal/api-client-libraries/compare/e4fc576245a3346beb6b5edb89ad0ccb03dfa655...c73114f026690637dccea57b21ee6f0a1eca5051)._