### PR TITLE
feat: add v5.7.0 package updates

### DIFF
--- a/docs/CreateNotificationSuccessResponse.md
+++ b/docs/CreateNotificationSuccessResponse.md
@@ -4,7 +4,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**id** | **str** | Notification identifier when the request created a notification. An empty string means no notification was created; read `errors` for details (HTTP may still be 200). | [optional] 
+**id** | **str** | Notification identifier when the request created a notification. An empty string means no notification was created; read `errors` for details (HTTP may still be 200). All OneSignal server SDKs expose message-sent / message-not-sent narrowing helpers (named idiomatically per language — e.g. `isMessageSent`, `is_message_sent`, `message_sent?`); prefer them over comparing `id` directly. | [optional] 
 **external_id** | **str, none_type** | Optional correlation / idempotency-related value from the API response. This is not the end-user External ID used for targeting recipients (that lives under `include_aliases.external_id`). | [optional] 
 **errors** | **bool, date, datetime, dict, float, int, list, str, none_type** | Polymorphic field: may be an array of human-readable strings and/or an object (for example with `invalid_aliases`, `invalid_external_user_ids`, or `invalid_player_ids`) depending on the API response; HTTP may still be 200 with partial success. Typed SDKs model this loosely so both shapes deserialize. | [optional] 
 **any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]

--- a/docs/DefaultApi.md
+++ b/docs/DefaultApi.md
@@ -2535,6 +2535,7 @@ with onesignal.ApiClient(configuration) as api_client:
     limit = 10  # How many notifications to return.  Max is 50.  Default is 50. (optional) 
     offset = 0  # Page offset.  Default is 0.  Results are sorted by queued_at in descending order.  queued_at is a representation of the time that the notification was queued at. (optional) 
     kind = 0  # Kind of notifications returned:   * unset - All notification types (default)   * `0` - Dashboard only   * `1` - API only   * `3` - Automated only  (optional) 
+    time_offset = "2025-01-01T00:00:00.000Z"  # Time-offset pagination cursor for sequential pulls of all messages.  Accepts either an ISO 8601 formatted timestamp (e.g. `2025-01-01T00:00:00.000Z`) or the opaque Base64 cursor token returned as `next_time_offset` in a prior response.  When set, results are sorted ascending by send_after and the standard `offset` parameter cannot be used.  Repeat the request with each `next_time_offset` until an empty notifications array is returned. (optional) 
 
     # example passing only required values which don't have defaults set
     try:
@@ -2550,7 +2551,7 @@ with onesignal.ApiClient(configuration) as api_client:
     # and optional values
     try:
         # View notifications
-        api_response = api_instance.get_notifications(app_id, limit=limit, offset=offset, kind=kind)
+        api_response = api_instance.get_notifications(app_id, limit=limit, offset=offset, kind=kind, time_offset=time_offset)
         pprint(api_response)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->get_notifications: %s\n" % e)
@@ -2567,6 +2568,7 @@ Name | Type | Description  | Notes
  **limit** | **int**| How many notifications to return.  Max is 50.  Default is 50. | [optional]
  **offset** | **int**| Page offset.  Default is 0.  Results are sorted by queued_at in descending order.  queued_at is a representation of the time that the notification was queued at. | [optional]
  **kind** | **int**| Kind of notifications returned:   * unset - All notification types (default)   * &#x60;0&#x60; - Dashboard only   * &#x60;1&#x60; - API only   * &#x60;3&#x60; - Automated only  | [optional]
+ **time_offset** | **str**| Time-offset pagination cursor for sequential pulls of all messages.  Accepts either an ISO 8601 formatted timestamp (e.g. &#x60;2025-01-01T00:00:00.000Z&#x60;) or the opaque Base64 cursor token returned as &#x60;next_time_offset&#x60; in a prior response.  When set, results are sorted ascending by send_after and the standard &#x60;offset&#x60; parameter cannot be used.  Repeat the request with each &#x60;next_time_offset&#x60; until an empty notifications array is returned. | [optional]
 
 ### Return type
 

--- a/docs/NotificationSlice.md
+++ b/docs/NotificationSlice.md
@@ -7,6 +7,8 @@ Name | Type | Description | Notes
 **total_count** | **int** |  | [optional] 
 **offset** | **int** |  | [optional] 
 **limit** | **int** |  | [optional] 
+**time_offset** | **str** | The time_offset cursor specified in the request, if any. | [optional] 
+**next_time_offset** | **str** | An opaque Base64 cursor token representing the next page of messages to fetch.  Present when time_offset was provided in the request.  Pass this value as time_offset on the next request to continue paginating. | [optional] 
 **notifications** | [**[NotificationWithMeta]**](NotificationWithMeta.md) |  | [optional] 
 **any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 

--- a/onesignal/api/default_api.py
+++ b/onesignal/api/default_api.py
@@ -1608,6 +1608,7 @@ class DefaultApi(object):
                     'limit',
                     'offset',
                     'kind',
+                    'time_offset',
                 ],
                 'required': [
                     'app_id',
@@ -1640,18 +1641,22 @@ class DefaultApi(object):
                         (int,),
                     'kind':
                         (int,),
+                    'time_offset':
+                        (str,),
                 },
                 'attribute_map': {
                     'app_id': 'app_id',
                     'limit': 'limit',
                     'offset': 'offset',
                     'kind': 'kind',
+                    'time_offset': 'time_offset',
                 },
                 'location_map': {
                     'app_id': 'query',
                     'limit': 'query',
                     'offset': 'query',
                     'kind': 'query',
+                    'time_offset': 'query',
                 },
                 'collection_format_map': {
                 }
@@ -5041,6 +5046,7 @@ class DefaultApi(object):
             limit (int): How many notifications to return.  Max is 50.  Default is 50.. [optional]
             offset (int): Page offset.  Default is 0.  Results are sorted by queued_at in descending order.  queued_at is a representation of the time that the notification was queued at.. [optional]
             kind (int): Kind of notifications returned:   * unset - All notification types (default)   * `0` - Dashboard only   * `1` - API only   * `3` - Automated only . [optional]
+            time_offset (str): Time-offset pagination cursor for sequential pulls of all messages.  Accepts either an ISO 8601 formatted timestamp (e.g. `2025-01-01T00:00:00.000Z`) or the opaque Base64 cursor token returned as `next_time_offset` in a prior response.  When set, results are sorted ascending by send_after and the standard `offset` parameter cannot be used.  Repeat the request with each `next_time_offset` until an empty notifications array is returned.. [optional]
             _return_http_data_only (bool): response data without head status
                 code and headers. Default is True.
             _preload_content (bool): if False, the urllib3.HTTPResponse object

--- a/onesignal/helpers.py
+++ b/onesignal/helpers.py
@@ -96,3 +96,30 @@ def create_notification_with_retry(api, notification, max_retries=3, base_delay=
         if delay > 0:
             time.sleep(delay)
         attempt += 1
+
+
+def is_message_sent(response):
+    """Return True when a POST /notifications 200 response is the "message
+    sent" branch -- a notification was created and ``id`` is a non-empty string.
+
+    POST /notifications returns 200 in two cases that share the
+    ``CreateNotificationSuccessResponse`` shape: a notification was created
+    (non-empty ``id``), or none was (empty ``id``, with ``errors`` carrying the
+    reason). Prefer this guard over inspecting ``id`` directly.
+
+    :param response: a ``CreateNotificationSuccessResponse``
+    :return: True if a notification was created
+    """
+    notification_id = getattr(response, 'id', None)
+    return isinstance(notification_id, str) and len(notification_id) > 0
+
+
+def is_message_not_sent(response):
+    """Return True when a POST /notifications 200 response is the "message not
+    sent" branch -- no notification was created (``id`` is absent or empty);
+    inspect ``errors`` for why.
+
+    :param response: a ``CreateNotificationSuccessResponse``
+    :return: True if no notification was created
+    """
+    return not is_message_sent(response)

--- a/onesignal/model/create_notification_success_response.py
+++ b/onesignal/model/create_notification_success_response.py
@@ -139,7 +139,7 @@ class CreateNotificationSuccessResponse(ModelNormal):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
-            id (str): Notification identifier when the request created a notification. An empty string means no notification was created; read `errors` for details (HTTP may still be 200).. [optional]  # noqa: E501
+            id (str): Notification identifier when the request created a notification. An empty string means no notification was created; read `errors` for details (HTTP may still be 200). All OneSignal server SDKs expose message-sent / message-not-sent narrowing helpers (named idiomatically per language — e.g. `isMessageSent`, `is_message_sent`, `message_sent?`); prefer them over comparing `id` directly.. [optional]  # noqa: E501
             external_id (str, none_type): Optional correlation / idempotency-related value from the API response. This is not the end-user External ID used for targeting recipients (that lives under `include_aliases.external_id`).. [optional]  # noqa: E501
             errors (bool, date, datetime, dict, float, int, list, str, none_type): Polymorphic field: may be an array of human-readable strings and/or an object (for example with `invalid_aliases`, `invalid_external_user_ids`, or `invalid_player_ids`) depending on the API response; HTTP may still be 200 with partial success. Typed SDKs model this loosely so both shapes deserialize.. [optional]  # noqa: E501
         """
@@ -227,7 +227,7 @@ class CreateNotificationSuccessResponse(ModelNormal):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
-            id (str): Notification identifier when the request created a notification. An empty string means no notification was created; read `errors` for details (HTTP may still be 200).. [optional]  # noqa: E501
+            id (str): Notification identifier when the request created a notification. An empty string means no notification was created; read `errors` for details (HTTP may still be 200). All OneSignal server SDKs expose message-sent / message-not-sent narrowing helpers (named idiomatically per language — e.g. `isMessageSent`, `is_message_sent`, `message_sent?`); prefer them over comparing `id` directly.. [optional]  # noqa: E501
             external_id (str, none_type): Optional correlation / idempotency-related value from the API response. This is not the end-user External ID used for targeting recipients (that lives under `include_aliases.external_id`).. [optional]  # noqa: E501
             errors (bool, date, datetime, dict, float, int, list, str, none_type): Polymorphic field: may be an array of human-readable strings and/or an object (for example with `invalid_aliases`, `invalid_external_user_ids`, or `invalid_player_ids`) depending on the API response; HTTP may still be 200 with partial success. Typed SDKs model this loosely so both shapes deserialize.. [optional]  # noqa: E501
         """

--- a/onesignal/model/notification_slice.py
+++ b/onesignal/model/notification_slice.py
@@ -91,6 +91,8 @@ class NotificationSlice(ModelNormal):
             'total_count': (int,),  # noqa: E501
             'offset': (int,),  # noqa: E501
             'limit': (int,),  # noqa: E501
+            'time_offset': (str,),  # noqa: E501
+            'next_time_offset': (str,),  # noqa: E501
             'notifications': ([NotificationWithMeta],),  # noqa: E501
         }
 
@@ -103,6 +105,8 @@ class NotificationSlice(ModelNormal):
         'total_count': 'total_count',  # noqa: E501
         'offset': 'offset',  # noqa: E501
         'limit': 'limit',  # noqa: E501
+        'time_offset': 'time_offset',  # noqa: E501
+        'next_time_offset': 'next_time_offset',  # noqa: E501
         'notifications': 'notifications',  # noqa: E501
     }
 
@@ -150,6 +154,8 @@ class NotificationSlice(ModelNormal):
             total_count (int): [optional]  # noqa: E501
             offset (int): [optional]  # noqa: E501
             limit (int): [optional]  # noqa: E501
+            time_offset (str): The time_offset cursor specified in the request, if any.. [optional]  # noqa: E501
+            next_time_offset (str): An opaque Base64 cursor token representing the next page of messages to fetch.  Present when time_offset was provided in the request.  Pass this value as time_offset on the next request to continue paginating.. [optional]  # noqa: E501
             notifications ([NotificationWithMeta]): [optional]  # noqa: E501
         """
 
@@ -239,6 +245,8 @@ class NotificationSlice(ModelNormal):
             total_count (int): [optional]  # noqa: E501
             offset (int): [optional]  # noqa: E501
             limit (int): [optional]  # noqa: E501
+            time_offset (str): The time_offset cursor specified in the request, if any.. [optional]  # noqa: E501
+            next_time_offset (str): An opaque Base64 cursor token representing the next page of messages to fetch.  Present when time_offset was provided in the request.  Pass this value as time_offset on the next request to continue paginating.. [optional]  # noqa: E501
             notifications ([NotificationWithMeta]): [optional]  # noqa: E501
         """
 


### PR DESCRIPTION
## Release v5.7.0

### 🚀 Features
- feat: [SDK-4440] generate typed error-code catalog module per SDK
- feat: [SDK-4441] add idempotency-key retry helper for create-notification
- feat: [SDK-4441] expose createNotificationWithRetry as a client method
- feat: [SDK-4441] clamp retry helper backoff base to [1s, 60s]
- feat: [SDK-4776] expose time_offset pagination on get_notifications
- feat: [SDK-4781] add message-sent/not-sent narrowing helpers
- feat: [SDK-4781] refine narrowing-helper doc nudge and PHP null-safety

### 🐛 Bug Fixes
- fix: [SDK-4440] reclassify OVER_SUBSCRIBER_LIMIT as a template entry
- fix: [SDK-4438] surface object-shaped errors in error-messages accessors
- fix: [SDK-4440] trim OneSignalErrors catalog to a verified minimal set
- fix: [SDK-4776] append time_offset after kind in get_notifications

### 📚 Docs
- docs: [SDK-4441] add createNotificationWithRetry example to DefaultApi docs
- docs: [SDK-4440] fix OneSignalErrors usage example for the 200-status sentinel
- docs: clarify errorMessages excludes structured meta; show how to read it
- docs: demonstrate reading 409 conflict meta in CreateUser example
- docs: [SDK-4440] cross-link OneSignalErrors catalog from DefaultApi.md error handling

---
_Generated from [OneSignal/api-client-libraries@e4fc576...2907ac8](https://github.com/OneSignal/api-client-libraries/compare/e4fc576245a3346beb6b5edb89ad0ccb03dfa655...2907ac87ca594fc5aee71ccfab5839f35b6a0f38)._