### PR TITLE
feat: add v5.7.0 package updates

### DIFF
--- a/docs/CreateNotificationSuccessResponse.md
+++ b/docs/CreateNotificationSuccessResponse.md
@@ -4,7 +4,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**id** | **str** | Notification identifier when the request created a notification. An empty string means no notification was created; read `errors` for details (HTTP may still be 200). | [optional] 
+**id** | **str** | Notification identifier when the request created a notification. An empty string means no notification was created; read `errors` for details (HTTP may still be 200). All OneSignal server SDKs expose message-sent / message-not-sent narrowing helpers (named idiomatically per language — e.g. `isMessageSent`, `is_message_sent`, `message_sent?`); prefer them over comparing `id` directly. | [optional] 
 **external_id** | **str, none_type** | Optional correlation / idempotency-related value from the API response. This is not the end-user External ID used for targeting recipients (that lives under `include_aliases.external_id`). | [optional] 
 **errors** | **bool, date, datetime, dict, float, int, list, str, none_type** | Polymorphic field: may be an array of human-readable strings and/or an object (for example with `invalid_aliases`, `invalid_external_user_ids`, or `invalid_player_ids`) depending on the API response; HTTP may still be 200 with partial success. Typed SDKs model this loosely so both shapes deserialize. | [optional] 
 **any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]

--- a/docs/DefaultApi.md
+++ b/docs/DefaultApi.md
@@ -161,6 +161,7 @@ Name | Type | Description  | Notes
 **400** | Bad Request |  -  |
 **404** | Not Found |  -  |
 **429** | Rate Limit Exceeded |  -  |
+**0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-python-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-python-api)
 
@@ -242,6 +243,7 @@ Name | Type | Description  | Notes
 |-------------|-------------|------------------|
 **200** | OK |  -  |
 **400** | Bad Request |  -  |
+**0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-python-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-python-api)
 
@@ -329,6 +331,7 @@ Name | Type | Description  | Notes
 **404** | Not Found |  -  |
 **409** | Conflict |  -  |
 **429** | Rate Limit Exceeded |  -  |
+**0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-python-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-python-api)
 
@@ -414,6 +417,7 @@ Name | Type | Description  | Notes
 **404** | Not Found |  -  |
 **409** | Conflict |  -  |
 **429** | Rate Limit Exceeded |  -  |
+**0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-python-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-python-api)
 
@@ -497,6 +501,7 @@ Name | Type | Description  | Notes
 |-------------|-------------|------------------|
 **200** | OK |  -  |
 **400** | Bad Request |  -  |
+**0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-python-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-python-api)
 
@@ -595,6 +600,7 @@ Name | Type | Description  | Notes
 **200** | OK |  -  |
 **400** | Bad Request |  -  |
 **429** | Rate Limit Exceeded |  -  |
+**0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-python-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-python-api)
 
@@ -684,6 +690,7 @@ Name | Type | Description  | Notes
 **400** | Bad Request |  -  |
 **401** | Unauthorized |  -  |
 **429** | Rate Limit Exceeded |  -  |
+**0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-python-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-python-api)
 
@@ -823,6 +830,7 @@ Name | Type | Description  | Notes
 **200** | OK, invalid_aliases, or No Subscribed Players If a message was successfully created, you will get a 200 response with a non-empty &#x60;id&#x60; for the notification. If the 200 response contains &#x60;invalid_aliases&#x60;, that marks devices that exist in the provided app_id but are no longer subscribed. If &#x60;id&#x60; is an empty string, no notification was created: check the &#x60;errors&#x60; array (for example messages such as \&quot;All included players are not subscribed\&quot;) even though HTTP status is still 200. This can happen when alias keys are wrong, External IDs do not resolve to subscribed users, or other validation issues. If no id is returned, then a message was not created and the targeted User IDs do not exist under the provided app_id. Any User IDs sent in the request that do not exist under the specified app_id will be ignored.  |  -  |
 **400** | Bad Request |  -  |
 **429** | Rate Limit Exceeded |  -  |
+**0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-python-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-python-api)
 
@@ -921,6 +929,7 @@ Name | Type | Description  | Notes
 **400** | Bad Request |  -  |
 **409** | Conflict |  -  |
 **429** | Rate Limit Exceeded |  -  |
+**0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-python-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-python-api)
 
@@ -1025,6 +1034,7 @@ Name | Type | Description  | Notes
 **404** | Not Found |  -  |
 **409** | Operation is not permitted due to user having the maximum number of subscriptions assigned |  -  |
 **429** | Rate Limit Exceeded |  -  |
+**0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-python-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-python-api)
 
@@ -1247,6 +1257,7 @@ Name | Type | Description  | Notes
 **200** | OK |  -  |
 **400** | Bad Request |  -  |
 **422** | Unprocessable Entity |  -  |
+**0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-python-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-python-api)
 
@@ -1385,6 +1396,7 @@ Name | Type | Description  | Notes
 **400** | Bad Request |  -  |
 **409** | Multiple User Identity Conflict |  -  |
 **429** | Rate Limit Exceeded |  -  |
+**0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-python-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-python-api)
 
@@ -1468,6 +1480,7 @@ Name | Type | Description  | Notes
 **404** | Not Found |  -  |
 **409** | Conflict |  -  |
 **429** | Rate Limit Exceeded |  -  |
+**0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-python-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-python-api)
 
@@ -1543,6 +1556,7 @@ Name | Type | Description  | Notes
 |-------------|-------------|------------------|
 **200** | OK |  -  |
 **400** | Bad Request |  -  |
+**0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-python-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-python-api)
 
@@ -1622,6 +1636,7 @@ Name | Type | Description  | Notes
 **400** | Bad Request |  -  |
 **404** | Not Found |  -  |
 **429** | Rate Limit Exceeded |  -  |
+**0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-python-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-python-api)
 
@@ -1699,6 +1714,7 @@ void (empty response body)
 **404** | Not Found |  -  |
 **409** | Conflict |  -  |
 **429** | Rate Limit Exceeded |  -  |
+**0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-python-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-python-api)
 
@@ -1776,6 +1792,7 @@ Name | Type | Description  | Notes
 **200** | OK |  -  |
 **400** | Bad Request |  -  |
 **404** | Not Found |  -  |
+**0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-python-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-python-api)
 
@@ -1854,6 +1871,7 @@ void (empty response body)
 **400** | Bad Request |  -  |
 **409** | Conflict |  -  |
 **429** | Rate Limit Exceeded |  -  |
+**0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-python-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-python-api)
 
@@ -1933,6 +1951,7 @@ Name | Type | Description  | Notes
 **400** | Bad Request |  -  |
 **404** | Not Found |  -  |
 **429** | Rate Limit Exceeded |  -  |
+**0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-python-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-python-api)
 
@@ -2029,6 +2048,7 @@ Name | Type | Description  | Notes
 **200** | OK |  -  |
 **400** | Bad Request |  -  |
 **429** | Rate Limit Exceeded |  -  |
+**0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-python-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-python-api)
 
@@ -2109,6 +2129,7 @@ Name | Type | Description  | Notes
 **400** | Bad Request |  -  |
 **404** | Not Found |  -  |
 **429** | Rate Limit Exceeded |  -  |
+**0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-python-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-python-api)
 
@@ -2185,6 +2206,7 @@ Name | Type | Description  | Notes
 **200** | OK |  -  |
 **400** | Bad Request |  -  |
 **404** | Not Found |  -  |
+**0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-python-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-python-api)
 
@@ -2261,6 +2283,7 @@ Name | Type | Description  | Notes
 **200** | OK |  -  |
 **400** | Bad Request |  -  |
 **429** | Rate Limit Exceeded |  -  |
+**0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-python-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-python-api)
 
@@ -2333,6 +2356,7 @@ This endpoint does not need any parameter.
 **200** | OK |  -  |
 **400** | Bad Request |  -  |
 **429** | Rate Limit Exceeded |  -  |
+**0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-python-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-python-api)
 
@@ -2412,6 +2436,7 @@ Name | Type | Description  | Notes
 **400** | Bad Request |  -  |
 **404** | Not Found |  -  |
 **429** | Rate Limit Exceeded |  -  |
+**0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-python-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-python-api)
 
@@ -2496,6 +2521,7 @@ Name | Type | Description  | Notes
 **400** | Bad Request |  -  |
 **404** | Not Found |  -  |
 **429** | Rate Limit Exceeded |  -  |
+**0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-python-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-python-api)
 
@@ -2535,6 +2561,7 @@ with onesignal.ApiClient(configuration) as api_client:
     limit = 10  # How many notifications to return.  Max is 50.  Default is 50. (optional) 
     offset = 0  # Page offset.  Default is 0.  Results are sorted by queued_at in descending order.  queued_at is a representation of the time that the notification was queued at. (optional) 
     kind = 0  # Kind of notifications returned:   * unset - All notification types (default)   * `0` - Dashboard only   * `1` - API only   * `3` - Automated only  (optional) 
+    time_offset = "2025-01-01T00:00:00.000Z"  # Time-offset pagination cursor for sequential pulls of all messages.  Accepts either an ISO 8601 formatted timestamp (e.g. `2025-01-01T00:00:00.000Z`) or the opaque Base64 cursor token returned as `next_time_offset` in a prior response.  When set, results are sorted ascending by send_after and the standard `offset` parameter cannot be used.  Repeat the request with each `next_time_offset` until an empty notifications array is returned. (optional) 
 
     # example passing only required values which don't have defaults set
     try:
@@ -2550,7 +2577,7 @@ with onesignal.ApiClient(configuration) as api_client:
     # and optional values
     try:
         # View notifications
-        api_response = api_instance.get_notifications(app_id, limit=limit, offset=offset, kind=kind)
+        api_response = api_instance.get_notifications(app_id, limit=limit, offset=offset, kind=kind, time_offset=time_offset)
         pprint(api_response)
     except onesignal.ApiException as e:
         print("Exception when calling DefaultApi->get_notifications: %s\n" % e)
@@ -2567,6 +2594,7 @@ Name | Type | Description  | Notes
  **limit** | **int**| How many notifications to return.  Max is 50.  Default is 50. | [optional]
  **offset** | **int**| Page offset.  Default is 0.  Results are sorted by queued_at in descending order.  queued_at is a representation of the time that the notification was queued at. | [optional]
  **kind** | **int**| Kind of notifications returned:   * unset - All notification types (default)   * &#x60;0&#x60; - Dashboard only   * &#x60;1&#x60; - API only   * &#x60;3&#x60; - Automated only  | [optional]
+ **time_offset** | **str**| Time-offset pagination cursor for sequential pulls of all messages.  Accepts either an ISO 8601 formatted timestamp (e.g. &#x60;2025-01-01T00:00:00.000Z&#x60;) or the opaque Base64 cursor token returned as &#x60;next_time_offset&#x60; in a prior response.  When set, results are sorted ascending by send_after and the standard &#x60;offset&#x60; parameter cannot be used.  Repeat the request with each &#x60;next_time_offset&#x60; until an empty notifications array is returned. | [optional]
 
 ### Return type
 
@@ -2589,6 +2617,7 @@ Name | Type | Description  | Notes
 **200** | OK |  -  |
 **400** | Bad Request |  -  |
 **429** | Rate Limit Exceeded |  -  |
+**0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-python-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-python-api)
 
@@ -2686,6 +2715,7 @@ Name | Type | Description  | Notes
 **200** | OK |  -  |
 **400** | Bad Request |  -  |
 **429** | Rate Limit Exceeded |  -  |
+**0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-python-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-python-api)
 
@@ -2777,6 +2807,7 @@ Name | Type | Description  | Notes
 **201** | OK |  -  |
 **400** | Bad Request |  -  |
 **429** | Rate Limit Exceeded |  -  |
+**0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-python-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-python-api)
 
@@ -2857,6 +2888,7 @@ Name | Type | Description  | Notes
 **400** | Bad Request |  -  |
 **404** | Not Found |  -  |
 **429** | Rate Limit Exceeded |  -  |
+**0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-python-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-python-api)
 
@@ -2933,6 +2965,7 @@ Name | Type | Description  | Notes
 |-------------|-------------|------------------|
 **200** | OK |  -  |
 **400** | Bad Request |  -  |
+**0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-python-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-python-api)
 
@@ -3131,6 +3164,7 @@ Name | Type | Description  | Notes
 **201** | Created |  -  |
 **400** | Bad Request |  -  |
 **429** | Rate Limit Exceeded |  -  |
+**0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-python-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-python-api)
 
@@ -3217,6 +3251,7 @@ Name | Type | Description  | Notes
 **404** | Not Found |  -  |
 **409** | Conflict |  -  |
 **429** | Rate Limit Exceeded |  -  |
+**0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-python-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-python-api)
 
@@ -3297,6 +3332,7 @@ Name | Type | Description  | Notes
 **202** | OK |  -  |
 **400** | Bad Request |  -  |
 **429** | Rate Limit Exceeded |  -  |
+**0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-python-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-python-api)
 
@@ -3381,6 +3417,7 @@ Name | Type | Description  | Notes
 |-------------|-------------|------------------|
 **200** | OK |  -  |
 **400** | Bad Request |  -  |
+**0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-python-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-python-api)
 
@@ -3481,6 +3518,7 @@ Name | Type | Description  | Notes
 **200** | OK |  -  |
 **400** | Bad Request |  -  |
 **429** | Rate Limit Exceeded |  -  |
+**0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-python-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-python-api)
 
@@ -3660,6 +3698,7 @@ Name | Type | Description  | Notes
 **200** | OK |  -  |
 **400** | Bad Request |  -  |
 **429** | Rate Limit Exceeded |  -  |
+**0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-python-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-python-api)
 
@@ -3760,6 +3799,7 @@ void (empty response body)
 **404** | Not Found |  -  |
 **409** | Conflict |  -  |
 **429** | Rate Limit Exceeded |  -  |
+**0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-python-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-python-api)
 
@@ -3861,6 +3901,7 @@ Name | Type | Description  | Notes
 **202** | ACCEPTED |  -  |
 **400** | Bad Request |  -  |
 **404** | Not Found |  -  |
+**0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-python-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-python-api)
 
@@ -4085,6 +4126,7 @@ Name | Type | Description  | Notes
 |-------------|-------------|------------------|
 **200** | OK |  -  |
 **400** | Bad Request |  -  |
+**0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-python-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-python-api)
 
@@ -4202,6 +4244,7 @@ Name | Type | Description  | Notes
 **400** | Bad Request |  -  |
 **409** | Conflict |  -  |
 **429** | Rate Limit Exceeded |  -  |
+**0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-python-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-python-api)
 
@@ -4276,6 +4319,7 @@ Name | Type | Description  | Notes
 |-------------|-------------|------------------|
 **200** | OK |  -  |
 **400** | Bad Request |  -  |
+**0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-python-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-python-api)
 
@@ -4353,6 +4397,7 @@ Name | Type | Description  | Notes
 **200** | OK |  -  |
 **400** | Bad Request |  -  |
 **404** | Not Found |  -  |
+**0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-python-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-python-api)
 
@@ -4446,6 +4491,7 @@ Name | Type | Description  | Notes
 **200** | OK |  -  |
 **400** | Bad Request |  -  |
 **429** | Rate Limit Exceeded |  -  |
+**0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-python-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-python-api)
 

--- a/docs/NotificationSlice.md
+++ b/docs/NotificationSlice.md
@@ -7,6 +7,8 @@ Name | Type | Description | Notes
 **total_count** | **int** |  | [optional] 
 **offset** | **int** |  | [optional] 
 **limit** | **int** |  | [optional] 
+**time_offset** | **str** | The time_offset cursor specified in the request, if any. | [optional] 
+**next_time_offset** | **str** | An opaque Base64 cursor token representing the next page of messages to fetch.  Present when time_offset was provided in the request.  Pass this value as time_offset on the next request to continue paginating. | [optional] 
 **notifications** | [**[NotificationWithMeta]**](NotificationWithMeta.md) |  | [optional] 
 **any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 

--- a/onesignal/api/default_api.py
+++ b/onesignal/api/default_api.py
@@ -1608,6 +1608,7 @@ class DefaultApi(object):
                     'limit',
                     'offset',
                     'kind',
+                    'time_offset',
                 ],
                 'required': [
                     'app_id',
@@ -1640,18 +1641,22 @@ class DefaultApi(object):
                         (int,),
                     'kind':
                         (int,),
+                    'time_offset':
+                        (str,),
                 },
                 'attribute_map': {
                     'app_id': 'app_id',
                     'limit': 'limit',
                     'offset': 'offset',
                     'kind': 'kind',
+                    'time_offset': 'time_offset',
                 },
                 'location_map': {
                     'app_id': 'query',
                     'limit': 'query',
                     'offset': 'query',
                     'kind': 'query',
+                    'time_offset': 'query',
                 },
                 'collection_format_map': {
                 }
@@ -5041,6 +5046,7 @@ class DefaultApi(object):
             limit (int): How many notifications to return.  Max is 50.  Default is 50.. [optional]
             offset (int): Page offset.  Default is 0.  Results are sorted by queued_at in descending order.  queued_at is a representation of the time that the notification was queued at.. [optional]
             kind (int): Kind of notifications returned:   * unset - All notification types (default)   * `0` - Dashboard only   * `1` - API only   * `3` - Automated only . [optional]
+            time_offset (str): Time-offset pagination cursor for sequential pulls of all messages.  Accepts either an ISO 8601 formatted timestamp (e.g. `2025-01-01T00:00:00.000Z`) or the opaque Base64 cursor token returned as `next_time_offset` in a prior response.  When set, results are sorted ascending by send_after and the standard `offset` parameter cannot be used.  Repeat the request with each `next_time_offset` until an empty notifications array is returned.. [optional]
             _return_http_data_only (bool): response data without head status
                 code and headers. Default is True.
             _preload_content (bool): if False, the urllib3.HTTPResponse object

--- a/onesignal/helpers.py
+++ b/onesignal/helpers.py
@@ -96,3 +96,30 @@ def create_notification_with_retry(api, notification, max_retries=3, base_delay=
         if delay > 0:
             time.sleep(delay)
         attempt += 1
+
+
+def is_message_sent(response):
+    """Return True when a POST /notifications 200 response is the "message
+    sent" branch -- a notification was created and ``id`` is a non-empty string.
+
+    POST /notifications returns 200 in two cases that share the
+    ``CreateNotificationSuccessResponse`` shape: a notification was created
+    (non-empty ``id``), or none was (empty ``id``, with ``errors`` carrying the
+    reason). Prefer this guard over inspecting ``id`` directly.
+
+    :param response: a ``CreateNotificationSuccessResponse``
+    :return: True if a notification was created
+    """
+    notification_id = getattr(response, 'id', None)
+    return isinstance(notification_id, str) and len(notification_id) > 0
+
+
+def is_message_not_sent(response):
+    """Return True when a POST /notifications 200 response is the "message not
+    sent" branch -- no notification was created (``id`` is absent or empty);
+    inspect ``errors`` for why.
+
+    :param response: a ``CreateNotificationSuccessResponse``
+    :return: True if no notification was created
+    """
+    return not is_message_sent(response)

--- a/onesignal/model/create_notification_success_response.py
+++ b/onesignal/model/create_notification_success_response.py
@@ -139,7 +139,7 @@ class CreateNotificationSuccessResponse(ModelNormal):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
-            id (str): Notification identifier when the request created a notification. An empty string means no notification was created; read `errors` for details (HTTP may still be 200).. [optional]  # noqa: E501
+            id (str): Notification identifier when the request created a notification. An empty string means no notification was created; read `errors` for details (HTTP may still be 200). All OneSignal server SDKs expose message-sent / message-not-sent narrowing helpers (named idiomatically per language — e.g. `isMessageSent`, `is_message_sent`, `message_sent?`); prefer them over comparing `id` directly.. [optional]  # noqa: E501
             external_id (str, none_type): Optional correlation / idempotency-related value from the API response. This is not the end-user External ID used for targeting recipients (that lives under `include_aliases.external_id`).. [optional]  # noqa: E501
             errors (bool, date, datetime, dict, float, int, list, str, none_type): Polymorphic field: may be an array of human-readable strings and/or an object (for example with `invalid_aliases`, `invalid_external_user_ids`, or `invalid_player_ids`) depending on the API response; HTTP may still be 200 with partial success. Typed SDKs model this loosely so both shapes deserialize.. [optional]  # noqa: E501
         """
@@ -227,7 +227,7 @@ class CreateNotificationSuccessResponse(ModelNormal):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
-            id (str): Notification identifier when the request created a notification. An empty string means no notification was created; read `errors` for details (HTTP may still be 200).. [optional]  # noqa: E501
+            id (str): Notification identifier when the request created a notification. An empty string means no notification was created; read `errors` for details (HTTP may still be 200). All OneSignal server SDKs expose message-sent / message-not-sent narrowing helpers (named idiomatically per language — e.g. `isMessageSent`, `is_message_sent`, `message_sent?`); prefer them over comparing `id` directly.. [optional]  # noqa: E501
             external_id (str, none_type): Optional correlation / idempotency-related value from the API response. This is not the end-user External ID used for targeting recipients (that lives under `include_aliases.external_id`).. [optional]  # noqa: E501
             errors (bool, date, datetime, dict, float, int, list, str, none_type): Polymorphic field: may be an array of human-readable strings and/or an object (for example with `invalid_aliases`, `invalid_external_user_ids`, or `invalid_player_ids`) depending on the API response; HTTP may still be 200 with partial success. Typed SDKs model this loosely so both shapes deserialize.. [optional]  # noqa: E501
         """

--- a/onesignal/model/notification_slice.py
+++ b/onesignal/model/notification_slice.py
@@ -91,6 +91,8 @@ class NotificationSlice(ModelNormal):
             'total_count': (int,),  # noqa: E501
             'offset': (int,),  # noqa: E501
             'limit': (int,),  # noqa: E501
+            'time_offset': (str,),  # noqa: E501
+            'next_time_offset': (str,),  # noqa: E501
             'notifications': ([NotificationWithMeta],),  # noqa: E501
         }
 
@@ -103,6 +105,8 @@ class NotificationSlice(ModelNormal):
         'total_count': 'total_count',  # noqa: E501
         'offset': 'offset',  # noqa: E501
         'limit': 'limit',  # noqa: E501
+        'time_offset': 'time_offset',  # noqa: E501
+        'next_time_offset': 'next_time_offset',  # noqa: E501
         'notifications': 'notifications',  # noqa: E501
     }
 
@@ -150,6 +154,8 @@ class NotificationSlice(ModelNormal):
             total_count (int): [optional]  # noqa: E501
             offset (int): [optional]  # noqa: E501
             limit (int): [optional]  # noqa: E501
+            time_offset (str): The time_offset cursor specified in the request, if any.. [optional]  # noqa: E501
+            next_time_offset (str): An opaque Base64 cursor token representing the next page of messages to fetch.  Present when time_offset was provided in the request.  Pass this value as time_offset on the next request to continue paginating.. [optional]  # noqa: E501
             notifications ([NotificationWithMeta]): [optional]  # noqa: E501
         """
 
@@ -239,6 +245,8 @@ class NotificationSlice(ModelNormal):
             total_count (int): [optional]  # noqa: E501
             offset (int): [optional]  # noqa: E501
             limit (int): [optional]  # noqa: E501
+            time_offset (str): The time_offset cursor specified in the request, if any.. [optional]  # noqa: E501
+            next_time_offset (str): An opaque Base64 cursor token representing the next page of messages to fetch.  Present when time_offset was provided in the request.  Pass this value as time_offset on the next request to continue paginating.. [optional]  # noqa: E501
             notifications ([NotificationWithMeta]): [optional]  # noqa: E501
         """
 


### PR DESCRIPTION
## Release v5.7.0

### 🚀 Features
- feat: [SDK-4440] generate typed error-code catalog module per SDK
- feat: [SDK-4441] add idempotency-key retry helper for create-notification
- feat: [SDK-4441] expose createNotificationWithRetry as a client method
- feat: [SDK-4441] clamp retry helper backoff base to [1s, 60s]
- feat: [SDK-4776] expose time_offset pagination on get_notifications
- feat: [SDK-4781] add message-sent/not-sent narrowing helpers
- feat: [SDK-4781] refine narrowing-helper doc nudge and PHP null-safety
- feat: [SDK-4790] declare default error responses for all operations

### 🐛 Bug Fixes
- fix: [SDK-4440] reclassify OVER_SUBSCRIBER_LIMIT as a template entry
- fix: [SDK-4438] surface object-shaped errors in error-messages accessors
- fix: [SDK-4440] trim OneSignalErrors catalog to a verified minimal set
- fix: [SDK-4776] append time_offset after kind in get_notifications

### 📚 Docs
- docs: [SDK-4441] add createNotificationWithRetry example to DefaultApi docs
- docs: [SDK-4440] fix OneSignalErrors usage example for the 200-status sentinel
- docs: clarify errorMessages excludes structured meta; show how to read it
- docs: demonstrate reading 409 conflict meta in CreateUser example
- docs: [SDK-4440] cross-link OneSignalErrors catalog from DefaultApi.md error handling

---
_Generated from [OneSignal/api-client-libraries@e4fc576...09ec934](https://github.com/OneSignal/api-client-libraries/compare/e4fc576245a3346beb6b5edb89ad0ccb03dfa655...09ec934ab3eec4c769d5dc0f3cf9ad9a3f088b26)._